### PR TITLE
Fix a typo and add a dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 parse
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-pasrse
+parse


### PR DESCRIPTION
"pasrse" doesn't exist, typo of "parse"
Pillow is required, but not listed in requirements.txt